### PR TITLE
gh-1: Allow for java 8  to be used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,10 +43,6 @@
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.1</version>
-                    <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>
@@ -294,6 +290,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <autoVersionSubmodules>true</autoVersionSubmodules>
+
+        <!-- specify this as properties so that new projects can use 1.8 -->
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
 
         <!-- releases of our own projects to use -->
         <!-- these should only be SNAPSHOTs when no release is available -->


### PR DESCRIPTION
Loosened restrictions around the maven compiler source and target so that new projects can use java 8