### PR TITLE
Fix for #7: add jackson 2.x managed dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,21 @@
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson2.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-core</artifactId>
                 <version>${hamcrest.version}</version>
@@ -301,7 +316,8 @@
         <freemarker.version>2.3.16</freemarker.version>
         <google-guava.version>16.0.1</google-guava.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <jackson.version>1.8.0</jackson.version>
+        <jackson.version>1.8.11</jackson.version>
+        <jackson2.version>2.7.9</jackson2.version>
         <jsr-305.version>1.3.9</jsr-305.version>
         <jstl.version>1.2</jstl.version>
         <junit.version>4.8.2</junit.version>


### PR DESCRIPTION
for core Jackson components. Also bump Jackson 1.x from 1.8.0 to 1.8.11 (latest patch for minor), should that still be used for something.
